### PR TITLE
Catch the Interrupt signal and gracefully quit

### DIFF
--- a/cmd/node-manager/runners.go
+++ b/cmd/node-manager/runners.go
@@ -26,6 +26,7 @@ func peerMgr(ctx context.Context, mgr wireguard.WireguardManager, cfgFile string
 				return err
 			}
 		case <-ctx.Done():
+			log.Println("cancelling peer manager")
 			return ctx.Err()
 		}
 		// call set peers

--- a/cmd/node-manager/svr.go
+++ b/cmd/node-manager/svr.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"expvar"
 	"fmt"
 	"log"
@@ -64,7 +65,9 @@ func NewNodeManagerServer(ctx context.Context, cfg NodeConfig, ipamClient ipamv1
 	peerCtx, cancel := context.WithCancel(ctx)
 	go func() {
 		err = peerMgr(peerCtx, wgManager, configFile)
-		panic(err)
+		if !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
 	}()
 
 	return &NodeManagerServer{


### PR DESCRIPTION
I tried this out in vagrant and found out that we leave some stuff behind when running the node-manager