### PR TITLE
Persist IPAM usage to json file

### DIFF
--- a/cmd/cluster-manager/main.go
+++ b/cmd/cluster-manager/main.go
@@ -20,14 +20,15 @@ var (
 )
 
 type ClusterManagerConfig struct {
-	prefix string
+	prefix        string
+	dataDirectory string
 }
 
 func main() {
 	log.Println("initializing cluster-manager")
 	c := config()
 	log.Println("initializing server")
-	s, err := server.NewServer(c.prefix)
+	s, err := server.NewServer(c.prefix, server.WithDataDir(c.dataDirectory))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -48,9 +49,11 @@ func main() {
 }
 
 func config() ClusterManagerConfig {
-	cidrPrefix := flag.String("cidr-prefix", "10.0.0.0/8", "Ipam CIDR prefix")
+	cidrPrefix := flag.String("cidr-prefix", "10.0.0.0/8", "IPAM CIDR prefix")
+	dataDir := flag.String("data-dir", "", "Data directory to store ipam and wireguard files in")
 	flag.Parse()
 	return ClusterManagerConfig{
-		prefix: *cidrPrefix,
+		prefix:        *cidrPrefix,
+		dataDirectory: *dataDir,
 	}
 }

--- a/cmd/node-manager/main.go
+++ b/cmd/node-manager/main.go
@@ -63,6 +63,7 @@ type NodeConfig struct {
 	InterfaceName      string
 	ConfigDirectory    string
 	ListenAddr         string
+	DataDirectory      string
 	Wireguard          WireguardNodeConfig
 }
 
@@ -88,6 +89,7 @@ func config() NodeConfig {
 	interfaceName := flag.String("wireguard-interface", "wg0", "wireguard interface name")
 	configDirectory := flag.String("wireguard-config-directory", "/etc/wireguard", "Wireguard configuration directory")
 	listenAddr := flag.String("addr", "localhost:5242", "node manager listen address")
+	dataDir := flag.String("data-dir", "", "Data directory to store ipam and wireguard files in")
 
 	flag.Parse()
 	addr = *wireguardEndpoint
@@ -110,6 +112,7 @@ func config() NodeConfig {
 		ClusterManagerAddr: clusterMgr,
 		ConfigDirectory:    *configDirectory,
 		ListenAddr:         *listenAddr,
+		DataDirectory:      *dataDir,
 		Wireguard: WireguardNodeConfig{
 			Endpoint:      addr,
 			InterfaceName: *interfaceName,

--- a/cmd/node-manager/svr.go
+++ b/cmd/node-manager/svr.go
@@ -81,7 +81,7 @@ func NewNodeManagerServer(ctx context.Context, cfg NodeConfig) (*NodeManagerServ
 		Route:     wgSelf.AllowedIPs,
 	}
 
-	svr, err := server.NewServer(cidr, server.WithNodeConfig(self))
+	svr, err := server.NewServer(cidr, server.WithNodeConfig(self), server.WithDataDir(cfg.DataDirectory))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/ipam.go
+++ b/pkg/server/ipam.go
@@ -156,6 +156,9 @@ func (s *Server) Alloc(
 		Alloc: alloc,
 	}
 
+	if err := s.ipam.save(ctx); err != nil {
+		return nil, err
+	}
 	log.Printf("Allocated new /%s CIDR %s\n", alloc.Netmask, alloc.Address)
 
 	return connect.NewResponse(response), nil

--- a/pkg/server/ipam.go
+++ b/pkg/server/ipam.go
@@ -3,8 +3,12 @@ package server
 import (
 	"context"
 	"expvar"
+	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/bufbuild/connect-go"
@@ -19,6 +23,84 @@ var (
 	wireguardExpvar                                  = new(expvar.Map).Init()
 	once                                             = &sync.Once{}
 )
+
+// ipam is a wrapper around github.com/metal-stack/go-ipam.Ipamer to make persisting and loading the ipam state easier
+type ipam struct {
+	goipam.Ipamer
+	persistFile string
+}
+
+const IpamDataFile = "ipam.json"
+
+func newIPAM(ctx context.Context, dataDir, cidr string) (*ipam, error) {
+	ipamer := goipam.New()
+
+	_, err := ipamer.NewPrefix(ctx, cidr)
+	if err != nil {
+		return nil, err
+	}
+	var persistFile string
+	if dataDir != "" {
+		persistFile = filepath.Join(dataDir, IpamDataFile)
+	}
+	ipam := &ipam{
+		persistFile: persistFile,
+		Ipamer:      ipamer,
+	}
+	if err := ipam.loadData(ctx); err != nil {
+		return nil, err
+	}
+	return ipam, nil
+}
+
+// save will dump ipam state from memory into a file
+func (i *ipam) save(ctx context.Context) error {
+	if i.persistFile == "" {
+		return nil
+	}
+	data, err := i.Ipamer.Dump(ctx)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(i.persistFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_SYNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(data)
+	return err
+}
+
+// loadData will load ipam state from the data directory
+func (i *ipam) loadData(ctx context.Context) error {
+	if _, err := os.Stat(i.persistFile); os.IsNotExist(err) {
+		return nil
+	}
+
+	err := i.deleteAllPrefixes(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to delete prefixes for loading %w", err)
+	}
+	b, err := ioutil.ReadFile(i.persistFile)
+	if err != nil {
+		return err
+	}
+	return i.Ipamer.Load(ctx, string(b))
+}
+
+func (i *ipam) deleteAllPrefixes(ctx context.Context) error {
+	prefixes, err := i.Ipamer.ReadAllPrefixCidrs(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to read prefixes for deletion %w", err)
+	}
+	for _, prefix := range prefixes {
+		_, err := i.Ipamer.DeletePrefix(ctx, prefix)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 type IPAM_MODE int
 

--- a/pkg/server/ipam_test.go
+++ b/pkg/server/ipam_test.go
@@ -2,9 +2,14 @@ package server
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/bufbuild/connect-go"
+	goipam "github.com/metal-stack/go-ipam"
 	"github.com/stretchr/testify/require"
 
 	ipamv1 "github.com/clly/wireguard-cni/gen/wgcni/ipam/v1"
@@ -47,5 +52,55 @@ func Test_Alloc(t *testing.T) {
 
 		})
 	}
+}
 
+func Test_NewIPAM(t *testing.T) {
+	const parentPrefix = "10.0.0.0/8"
+	testcases := map[string]struct {
+		withDataDir bool
+		prefixs     []string
+	}{
+		"EmptyDataDir": {
+			withDataDir: false,
+		},
+		"WithDataDir": {
+			withDataDir: true,
+		},
+		"WithStoredAllocs": {
+			withDataDir: true,
+			prefixs:     []string{"10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"},
+		},
+	}
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			r := require.New(t)
+			ctx := context.Background()
+			d := t.TempDir()
+			ipam, err := newIPAM(context.Background(), d, parentPrefix)
+			r.NoError(err)
+			for _, s := range testcase.prefixs {
+				_, err := ipam.AcquireSpecificChildPrefix(ctx, parentPrefix, s)
+				r.NoError(err)
+			}
+			r.NoError(ipam.save(ctx))
+			ipam, err = newIPAM(context.Background(), d, "10.0.0.0/8")
+			r.NoError(err)
+			r.NoError(ipam.save(ctx))
+			if !testcase.withDataDir {
+				r.NoFileExists(IpamDataFile)
+			} else {
+				r.FileExists(filepath.Join(d, IpamDataFile))
+			}
+
+			if testcase.prefixs != nil {
+				actual, err := ipam.ReadAllPrefixCidrs(ctx)
+				r.NoError(err)
+				sort.Strings(actual)
+				expectedPrefixes := append(testcase.prefixs, parentPrefix)
+				sort.Strings(expectedPrefixes)
+				r.EqualValues(expectedPrefixes, actual)
+			}
+
+		})
+	}
 }


### PR DESCRIPTION
* Create a wrapper around the go-ipam object to more easily save the data and load it on server start up
* Use the new ipam object when creating the server
* Unit test the new functionality
* Add a data directory flag

Closes #52 